### PR TITLE
Update containers to OpenVox Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v9.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2025-01-14)
+## [v10.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v10.0.0) (2025-03-19)
+- Feat: Switch to OpenVox Containers
+- Feat: Default to Openvox v8 of OpenVox-server and OpenVoxDB
+
+
+## [v9.6.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.6.0) (2025-01-14)
 - Feat: #191 enable use of secret for restic environment variables
 - Feat: enable use of Azure Blob Storage including AKS Workload Identity for Restic Backups
 - Fix: Update Restic Container to v0.17.3
@@ -18,105 +23,105 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Fix: #240 Readme updates to match corrected versions and container image locations
 - Fix: #235, #236 Cosmetic typo about singleCA.enable
 
-## [v9.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
+## [v9.5.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.5.2) (2024-06-18)
 - Fix: #233 - Allow puppetdb.fqdns.alternateServerNames to be configured
 
-## [v9.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.1) (2024-05-09)
+## [v9.5.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.5.1) (2024-05-09)
 - Fix: #228 - fixed check for puppet certs in a multimaster setup
 
-## [v9.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.0) (2024-05-09)
+## [v9.5.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.5.0) (2024-05-09)
 - Feat: ability to disable persistence of `var-dir` and `confd` volumes
 
-## [v9.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.2) (2024-05-03)
+## [v9.4.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.4.2) (2024-05-03)
 - Fix: #215 fixed ability to use customconfigs with PuppetDB
 
-## [v9.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.1) (2024-05-02)
+## [v9.4.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.4.1) (2024-05-02)
 - Feat: allow option to import CA to only deal with CA and not puppetdb
 
-## [v9.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.4.0) (2024-04-19)
+## [v9.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.4.0) (2024-04-19)
 - Fix: Update Vox Pupuli Containers
 
-## [v9.3.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.4) (2024-04-11)
+## [v9.3.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.3.4) (2024-04-11)
 - Fix: Bump bitnami/jmx-exporter to latest stable for container patches
 
-## [v9.3.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.3) (2024-04-10)
+## [v9.3.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.3.3) (2024-04-10)
 - Fix: Update cURL container to address CVE-2023-38545 & CVE-2023-38546
 
-## [v9.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.2) (2024-04-08)
+## [v9.3.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.3.2) (2024-04-08)
 - Fix: Fixes bug in puppet-preinstall template when puppetserver.preGeneratedCertsJob is enabled. 
 
-## [v9.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.1) (2024-04-03)
+## [v9.3.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.3.1) (2024-04-03)
 - Fix: Fixes bug when viaHttps.customCa is not provided
 
-## [v9.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.3.0) (2024-03-28)
+## [v9.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.3.0) (2024-03-28)
 - Feat: Use custom CA file for r10k HTTPS code repository
 
-## [v9.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.2.1) (2024-03-27)
+## [v9.2.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.2.1) (2024-03-27)
 - Fix: Add 'netrc' credentials documentation for r10k and hiera repos
 
-## [v9.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.2.0) (2024-04-05)
+## [v9.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.2.0) (2024-04-05)
 - Feat: Add `.Values.global.securityContext.fsGroup`
 - Fix: Add `spec.template.spec.securityContext.fsGroup` to prevent "Permission denied" error
 
-## [v9.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.1.0) (2024-01-31)
+## [v9.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.1.0) (2024-01-31)
 - Fix: Remove `PUPPETDB_JAVA_ARGS` value on puppetdb container additional variables, to avoid error `unrecognized option: -Xlog:gc....` that causes the puppetdb pod to crash.
 
-## [v9.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.0.0) (2023-12-08)
+## [v9.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v9.0.0) (2023-12-08)
 - Breaking: Update values structure for 'metrics' to allow for multiple exporters
 - Feat: Make serviceMonitor optional for all Prometheus exporters
 - Feat: Add jmx exporter for puppetserver master(s)/compiler(s)
 - Feat: Allow specifying annotations for puppetserver master/compiler and puppetdb pods
 - Maint: Add snapshots to all unittests and over masters/compilers with them
 
-## [v8.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.2.0) (2023-11-29)
+## [v8.2.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.2.0) (2023-11-29)
 - feat: GitHub Actions workflow: add lint, install and unittest for all PRs
 - feat: GitHub Actions workflow: simplify workflow_dispatch to aid releases from forks
 
-## [v8.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.2.0) (2023-11-27)
+## [v8.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.2.0) (2023-11-27)
 - Fix: Typo in compiler statefulset readiness probe scheme
 - Fix: `PUPPETDB_JAVA_ARGS` which includes `-Xlog:gc:` instead of the deprecated `-Xloggc` and uses an existing path
 - Fix: Broken r10k-code command for statefulset compilers & standardize r10k-code readiness probe usage
 - Feat: Environment variables loaded from secret key-value pairs
 
-## [v8.1.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.5) (2023-11-22)
+## [v8.1.5](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.5) (2023-11-22)
 - Fix: Typo in the restic backup template preventing chart from being deployed
 - Feat: Add ability to mount custom ca-certificates.crt from configMap for Restic
 
-## [v8.1.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.4) (2023-11-20)
+## [v8.1.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.4) (2023-11-20)
 - Fix: Utilize `puppetserver` and `puppetdb` containers provided by voxpupuli and bump default versions
 
-## [v8.1.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.3) (2023-09-24)
+## [v8.1.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.3) (2023-09-24)
 - Fix: Wrong init value of r10k-code deployment readinessprobe
 
-## [v8.1.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.2) (2023-08-16)
+## [v8.1.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.2) (2023-08-16)
 - Feat: allow parametrize readiness probe scheme
 
-## [v8.1.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.1) (2023-07-13)
+## [v8.1.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.1) (2023-07-13)
 - Fix: correct readinessprobe syntax
 
-## [v8.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v8.1.0) (2023-07-12)
+## [v8.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v8.1.0) (2023-07-12)
 - Feat: allows parametrized r10k code entrypoints
 
-## [v7.4.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.5) (2023-06-28)
+## [v7.4.5](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.5) (2023-06-28)
 - Fix: r10k pod needs a script to run. Added all the needed mountpoint
 
-## [v7.4.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.4) (2023-06-27)
+## [v7.4.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.4) (2023-06-27)
 - Fix: pgchecker doesn't work with external database. Added the possibility of setting external postgresql.hostname with .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME
 
-## [v7.4.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.3) (2023-05-10)
+## [v7.4.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.3) (2023-05-10)
 - Fix: puppet ca cronjob pvc claim name
 
-## [v7.4.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.2) (2023-03-14)
+## [v7.4.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.2) (2023-03-14)
 - Fix: puppet master deployment issue when running as root
 
-## [v7.4.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.1) (2023-02-17)
+## [v7.4.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.1) (2023-02-17)
 - Fix: Remove r10k & hiera configuration in preinstall job
 - Fix: Preserve the whole tree file under /etc/puppetlabs/puppetserver when using the chart asNonRoot
 - Fix: Add capability compatibility for Azure
 - FIx: Manage hiera config in deployment to reload the pod automatically
 
 
-## [v7.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.0) (2023-02-06)
+## [v7.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.4.0) (2023-02-06)
 - Feat: allow to `runAsNonRoot` puppetserver **deployement** (masters & compilers) pods
 - Feat: add `PodDisruptionBudget`
 - Feat: add `networkPolicy`
@@ -126,10 +131,10 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Fix: puppetserver restart issue because of certificate name
 - Fix: error in puppetserver log about `dropsonde`
 
-## [v7.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.3.1) (2023-02-07)
+## [v7.3.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.3.1) (2023-02-07)
 - Fix: remove duplicate labels on puppetboard ingress
 
-## [v7.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.3.0) (2023-01-30)
+## [v7.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.3.0) (2023-01-30)
 - Feat: Add puppetdb exporter (https://github.com/camptocamp/prometheus-puppetdb-exporter)
 - Feat: starting to add unit test with Helm unittest
 - Fix: issue with single master, `env` key was missing and raised an error
@@ -138,13 +143,13 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Feat: bump puppetboard version to `4.2.5`
 - Feat: Improve pods security
 
-## [v7.2.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.2.2) (2023-01-xx)
-- Fix `storage.annotations` issue (https://github.com/puppetlabs/puppetserver-helm-chart/issues/148) apply code from PR https://github.com/puppetlabs/puppetserver-helm-chart/pull/149
+## [v7.2.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.2.2) (2023-01-xx)
+- Fix `storage.annotations` issue (https://github.com/OpenVoxProject/openvox-helm-chart/issues/148) apply code from PR https://github.com/OpenVoxProject/openvox-helm-chart/pull/149
 
-## [v7.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.2.1) (2023-01-23)
+## [v7.2.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.2.1) (2023-01-23)
 - Fix: remove `timeout [-t SECS]` change from BusyBox v1.29.3 to BusyBox v1.33.1 `timeout SECS`
 
-## [v7.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.2.0) (2023-01-18)
+## [v7.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.2.0) (2023-01-18)
 - Fix: puppetdb pvc deletion when preinstall job finnish before puppetdb pod start
 - Feat: Allow crl to be updated as Kubernetes cron job instead of pod side car (share the crl between all deployment)
 - Feat: Allow compilers to run as Deployment
@@ -153,8 +158,8 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Feat: use templating value for r10k image (to avoid duplication)
 - Feat: allow running r10k a pod instead sidecar (share r10k code between all deployment)
 
-## [v7.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.1.0) (2023-01-16)
-- Fix `extraLabels` issue (https://github.com/puppetlabs/puppetserver-helm-chart/issues/135) apply code from PR https://github.com/puppetlabs/puppetserver-helm-chart/pull/137
+## [v7.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.1.0) (2023-01-16)
+- Fix `extraLabels` issue (https://github.com/OpenVoxProject/openvox-helm-chart/issues/135) apply code from PR https://github.com/OpenVoxProject/openvox-helm-chart/pull/137
 - Fix: Rename all kubernetes resource with the release name as prefix
 - Fix: move all configmap in /tmp to avoid Read Only error in puppetserver init container
 - Fix: do not create r10k code credential secret if ssh or https existingSecret
@@ -163,7 +168,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Fix: crl script execution on puppetdb
 - feat: bump R10k to `v3.15.2`.
 
-## [v7.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.0.0) (2023-01-05)
+## [v7.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v7.0.0) (2023-01-05)
 
 - fix: autoscaling apiVersion, `autoscaling/v2` is available since 1.23
 - fix: postgresql dependency (upgrade to the lastest available chart `12.1.6`)
@@ -174,42 +179,42 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - feat: bump Puppetboard to `v4.2.4`.
 - fix: move configmap in /tmp to avoid Read Only error in puppetserver init container
 
-## [v6.8.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.2) (2022-12-31)
+## [v6.8.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.8.2) (2022-12-31)
 
 - fix: set postgresql.fullnameOverride to match chart name, avoids error when release name is different
 
-## [v6.8.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.1) (2022-12-07)
+## [v6.8.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.8.1) (2022-12-07)
 
 - fix: change order of scripts in master init or it will error out if compliers are enabled
 - fix: add PUPPET_SSL_DIR env var and change check_for_masters.sh or init would wait indefinitely for ssl generation when running multi master
 - fix: change from deprecated autoscaling/v2beta2 HorizontalPodAutoscaler to autoscaling/v2
 
-## [v6.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.8.0) (2022-10-26)
+## [v6.8.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.8.0) (2022-10-26)
 
 - fix: Save crl to defined filename
 
-## [v6.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.7.0) (2022-10-17)
+## [v6.7.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.7.0) (2022-10-17)
 
 - fix: have r10k-hiera extraSettings and extraRepos act like r10k-code and not print empty {} in r10k_hiera.yaml
 - feat: add .Values.r10k.hiera.defaultRepoExtraConf and .Values.r10k.code.defaultRepoExtraConf to pass in yaml config for r10k_code.yaml and r10k_hiera.yaml configs
 
-## [v6.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.6.0) (2022-10-04)
+## [v6.6.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.6.0) (2022-10-04)
 
 - feat: Allow to change load balancer type for puppet master if compilers are not used
 
-## [v6.5.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.3) (2022-08-19)
+## [v6.5.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.5.3) (2022-08-19)
 
 - fix: Prevent errors when not specifying r10k.code.extraSettings or r10k.code.extraRepos
 
-## [v6.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.2) (2022-08-18)
+## [v6.5.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.5.2) (2022-08-18)
 
 - fix: Prevent errors when not specifying extraInitArgs
 
-## [v6.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.1) (2022-08-17)
+## [v6.5.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.5.1) (2022-08-17)
 
 - fix: add -t flag to timeout for r10k:3.14.0 and below
 
-## [v6.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.5.0) (2022-07-29)
+## [v6.5.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.5.0) (2022-07-29)
 
 - feat: optional deployment of the puppetdb component (default true)
 - feat: remove privileged from securityContext (I do not understand why it was used/needed??)
@@ -221,16 +226,16 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - fix: puppet service configured as ClusterIP only.
 - fix: if compilers are deployed remove r10k container & code volumes from masters
 
-## [v6.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.4.0) (2022-06-30)
+## [v6.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.4.0) (2022-06-30)
 
 - feat: add r10k cron job `splay`, `splayLimit` and `timeout` params
 
-## [v6.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.3.0) (2022-06-29)
+## [v6.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.3.0) (2022-06-29)
 
 - feat: add `extraContainers` to both masters and compilers
 - feat: add r10k cron job `successFile` params
 
-## [v6.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.2.0) (2022-06-08)
+## [v6.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.2.0) (2022-06-08)
 
 - feat: update labels (match with Well-Known Labels) & add `extraLabels`
 - feat: move dependencies charts in `Charts.yaml`
@@ -240,14 +245,14 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - fix: update documentation for `puppetdb.service`
 - fix: puppetdb `update-crl` sidecar crash on some restart
 
-## [v6.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.1.0) (2022-06-07)
+## [v6.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.1.0) (2022-06-07)
 
 - fix: postgresql dependency. bump from `10.4.*` to `10.16.*` (https://github.com/bitnami/charts/issues/10539)
 - feat: drop Helm chart v2 support
 - feat: improve puppetserver (master & compiler) startup with `startupProbe`
 - feat: allow overriding harcoded variables
 
-## [v6.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.0.0) (2022-06-01)
+## [v6.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v6.0.0) (2022-06-01)
 
 - feat: Single CA support (https://puppet.com/docs/puppet/7/config_ssl_external_ca.html)
 - fix: define podsecuritypolicy.apiVersion
@@ -255,141 +260,141 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - fix puppetdb volume issue when use `customPersistentVolumeClaim`
 - refactoring serviceAccount name
 
-## [v5.20.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.20.0) (2022-05-31)
+## [v5.20.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.20.0) (2022-05-31)
 
 - Allow r10k cron jobs to be disabled
 - Allow multi hieradata repos
 - restart automatically pods if r10k or hiera configmap or secret change
 
-## [v5.19.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.19.0) (2022-05-27)
+## [v5.19.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.19.0) (2022-05-27)
 
 - feat: deploy only necessary configuration regarding the solution (secret, keys defined in values.yaml, configmap )
 - feat deploy only the most secure configuration (secret > keys defined in values.yaml > configMap)
 - feat: generate a warning if configmap or keys are defined in values.yaml is used
 - feat: generate an error if keys are defined in values.yaml and if .Values.eyaml.public_key or .Values.eyaml.private_key is missing
 
-## [v5.18.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.18.0) (2022-05-20)
+## [v5.18.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.18.0) (2022-05-20)
 
 - feat: add pod security policies
 
-## [v5.17.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.17.0) (2022-04-13)
+## [v5.17.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.17.0) (2022-04-13)
 
 - fix: delete parameter '--strip-components 1' of Puppetserver certificate (unzip)
 
-## [v5.16.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.16.0) (2022-04-05)
+## [v5.16.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.16.0) (2022-04-05)
 
 - feat: make update strategy configurable
 
-## [v5.15.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.15.0) (2022-04-20)
+## [v5.15.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.15.0) (2022-04-20)
 
 - feat: use k8s secrets instead of configmaps for eyaml secrets
 
-## [v5.14.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.14.0) (2021-12-01)
+## [v5.14.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.14.0) (2021-12-01)
 
 - feat: bump Puppetserver to `v7.4.2`.
 - feat: bump PuppetDB to `v7.7.1`.
 - feat: bump R10K to `v3.13.0`.
 - feat: bump Puppetboard to `v3.3.0`.
 
-## [v5.13.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.13.0) (2021-11-29)
+## [v5.13.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.13.0) (2021-11-29)
 
 - feat(eyaml): allow more than one pub/priv keypair in existing eyaml key map
 
-## [v5.12.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.12.0) (2021-09-21)
+## [v5.12.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.12.0) (2021-09-21)
 
 - feat: add support for Ingress `pathType` and `ingressClassName`.
 - feat: bump Puppetserver to `v7.3.0`.
 - feat: bump PuppetDB to `v7.5.2`.
 
-## [v5.11.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.11.0) (2021-08-30)
+## [v5.11.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.11.0) (2021-08-30)
 
 - fix: set securityContext for puppetboard container
 
-## [v5.10.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.10.0) (2021-08-30)
+## [v5.10.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.10.0) (2021-08-30)
 
 - feat: allow to expose puppetdb service outside of the kubernetes cluster
 
-## [v5.9.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.9.0) (2021-08-12)
+## [v5.9.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.9.0) (2021-08-12)
 
 - feat: allow to override PUPPETDB_POSTGRES_HOSTNAME for puppetdb container
 
-## [v5.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.8.0) (2021-07-22)
+## [v5.8.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.8.0) (2021-07-22)
 
 - feat: Add r10k.code.extraSettings and r10k.hiera.extraSettings
 - feat: Add viaHttps options for r10k.code
 
-## [v5.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.7.0) (2021-07-22)
+## [v5.7.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.7.0) (2021-07-22)
 
 - update: update to new api version (networking.k8s.io/v1) of ingress (v1.19+)
 
-## [v5.6.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.2) (2021-07-21)
+## [v5.6.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.6.2) (2021-07-21)
 
 - fix: add pathType Prefix to puppetboard ingress
 
-## [v5.6.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.1) (2021-07-20)
+## [v5.6.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.6.1) (2021-07-20)
 
 - fix: use correct puppetdb certs in puppetboard
 - fix: persist CA, now located in /etc/puppetlabs/puppetserver/ca/
 
-## [v5.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.6.0) (2021-05-01)
+## [v5.6.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.6.0) (2021-05-01)
 
 - update: Puppetserver to `v7.1.2`; PuppetDB to `v7.2.0`; r10k to `v3.8.0`; PostgreSQL chart to `v10.4.*`.
-- fix: [Wrong parameter name in README to disable autosign](https://github.com/puppetlabs/puppetserver-helm-chart/issues/79).
+- fix: [Wrong parameter name in README to disable autosign](https://github.com/OpenVoxProject/openvox-helm-chart/issues/79).
 - fix: bad naming for PuppetDB extra containers variable.
 - fix: add missing placeholder for PuppetDB extra containers in `values.yaml`.
 - fix: wrong url to Puppetserver chart v5.5.0 in `CHANGELOG`.
 
-## [v5.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.5.0) (2021-04-30)
+## [v5.5.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.5.0) (2021-04-30)
 
 - fix: use puppetboard.port in puppetboard-ingress.yaml
 - fix: use proper syntax for extra containers in puppetdb-deployment.yaml
 - fix: force targetPorts in puppetdb-service.yaml
 - enhancement: allow to specify puppetboard.service.targetPort
 
-## [v5.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.4.0) (2021-04-26)
+## [v5.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.4.0) (2021-04-26)
 
 - Use official Puppetboard image, use port 9090, and allow extra PuppetDB containers.
 
-## [v5.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.3.0) (2021-04-22)
+## [v5.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.3.0) (2021-04-22)
 
 - Add ability to ovewrite PuppetBoard variables in order to work properly with newer PuppetDB versions.
 
-## [v5.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.2.0) (2021-03-29)
+## [v5.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.2.0) (2021-03-29)
 
 - Add ability to change PVC accessModes.
 
-## [v5.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.1.0) (2021-02-07)
+## [v5.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.1.0) (2021-02-07)
 
 - Add ability to use custom PVCs.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v5.0.4...v5.1.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v5.0.4...v5.1.0)
 
-## [v5.0.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.0.4) (2020-11-02)
+## [v5.0.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.0.4) (2020-11-02)
 
 - Fix PuppetBoard showing "Internal server 500" when metric menu clicked.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v5.0.3...v5.0.4)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v5.0.3...v5.0.4)
 
-## [v5.0.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.0.3) (2020-11-01)
+## [v5.0.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.0.3) (2020-11-01)
 
 - Fix for r10k_code_cronjob.sh and r10k_hiera_cronjob.sh syntax error with `map[]`
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v5.0.2...v5.0.3)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v5.0.2...v5.0.3)
 
-## [v5.0.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.0.2) (2020-10-30)
+## [v5.0.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.0.2) (2020-10-30)
 
 - Fix for `DNS_ALT_NAMES` for non-compiler deployments.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v5.0.1...v5.0.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v5.0.1...v5.0.2)
 
-## [v5.0.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.0.1) (2020-09-19)
+## [v5.0.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.0.1) (2020-09-19)
 
 - Fix for resource names of Horizontal Pod Autoscalers.
 - Several `README` updates.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v5.0.0...v5.0.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v5.0.0...v5.0.1)
 
-## [v5.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v5.0.0) (2020-09-12)
+## [v5.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v5.0.0) (2020-09-12)
 
 - Externalize the creation of PostgreSQL backend using the Bitnami's PostgreSQL Helm chart.
 - Add high-availability and performance read replicas support for PostgreSQL.
@@ -402,9 +407,9 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Add `CODEOWNERS`.
 - Numerous other small tweaks.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.4.0...v5.0.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.4.0...v5.0.0)
 
-## [v4.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.4.0) (2020-08-24)
+## [v4.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.4.0) (2020-08-24)
 
 - Allow for changing the default Puppet Server ports for Masters and Compilers.
 - Switch to percentage `rollingUpdate` strategy for Puppet Masters.
@@ -413,38 +418,38 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Code style fixes in "values.yaml".
 - Improve `Testing the Deployed Chart Resources` in `README.md`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.3.0...v4.4.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.3.0...v4.4.0)
 
-## [v4.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.3.0) (2020-07-24)
+## [v4.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.3.0) (2020-07-24)
 
 - Liveness and readiness probes for Puppet Server.
 - Adjust further resource naming.
 - Style improvements in `README`.
 - Small fixes in `values`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.2.1...v4.3.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.2.1...v4.3.0)
 
-## [v4.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.2.1) (2020-07-08)
+## [v4.2.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.2.1) (2020-07-08)
 
 - Fix naming for Puppet Server Masters' Ingress.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.2.0...v4.2.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.2.0...v4.2.1)
 
-## [v4.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.2.0) (2020-06-23)
+## [v4.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.2.0) (2020-06-23)
 
 - Add Helm v2 backward compatibility.
 - Update README to reflect Helm v2 backward compatibility.
 - Improve post-deployment NOTES to show recommended Puppet Server Masters K8s Service name.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.1.1...v4.2.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.1.1...v4.2.0)
 
-## [v4.1.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.1.1) (2020-06-22)
+## [v4.1.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.1.1) (2020-06-22)
 
 - Small adjustments in `README` for new chart app name and new default Puppetboard image owner.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.1.0...v4.1.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.1.0...v4.1.1)
 
-## [v4.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.1.0) (2020-06-22)
+## [v4.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.1.0) (2020-06-22)
 
 - Rework Puppetboard support.
 - Add Puppetboard Service.
@@ -454,9 +459,9 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Other small improvements and fixes.
 - Update `OWNERS`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v4.0.0...v4.1.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v4.0.0...v4.1.0)
 
-## [v4.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v4.0.0) (2020-06-08)
+## [v4.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v4.0.0) (2020-06-08)
 
 - Support for multiple Puppetserver Compilers (optionally) on different K8s nodes (incl. across different cloud zones).
 - Improved support for multiple Puppetserver Masters.
@@ -473,22 +478,22 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Various small improvements and fixes.
 - Simpler documentation.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v3.0.2...v4.0.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v3.0.2...v4.0.0)
 
-## [v3.0.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v3.0.2) (2020-05-01)
+## [v3.0.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v3.0.2) (2020-05-01)
 
 - Add Puppet repo instruction to `README`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v3.0.1...v3.0.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v3.0.1...v3.0.2)
 
-## [v3.0.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v3.0.1) (2020-05-01)
+## [v3.0.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v3.0.1) (2020-05-01)
 
 - Documentation updates to reflect the new GitHub repo and contact details of the chart.
 - Updated `install` and `test` instructions.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v3.0.0...v3.0.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v3.0.0...v3.0.1)
 
-## [v3.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v3.0.0) (2020-04-05)
+## [v3.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v3.0.0) (2020-04-05)
 
 - Helm v3 support.
 - Improved documentation.
@@ -496,119 +501,119 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Bump versions of Puppet Server (to v6.9.2) and PuppetDB (to v6.9.1).
 - Other small fixes.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.8.2...v3.0.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.8.2...v3.0.0)
 
-## [v1.8.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.8.2) (2020-03-22)
+## [v1.8.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.8.2) (2020-03-22)
 
 - Better default auto-scaling and resource limits values for Puppetserver.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.8.1...v1.8.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.8.1...v1.8.2)
 
-## [v1.8.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.8.1) (2020-03-21)
+## [v1.8.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.8.1) (2020-03-21)
 
 - Fix auto-scaling of Puppetserver.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.8.0...v1.8.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.8.0...v1.8.1)
 
-## [v1.8.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.8.0) (2020-03-13)
+## [v1.8.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.8.0) (2020-03-13)
 
 - Better distinction between storage selectors.
 - Bump default versions: Puppetserver to `6.9.0` and PuppetDB to `6.9.0`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.7.2...v1.8.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.7.2...v1.8.0)
 
-## [v1.7.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.7.2) (2020-02-11)
+## [v1.7.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.7.2) (2020-02-11)
 
 - Improve further `Chart.yaml`.
 - Clean outdated comments in Values file.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.7.1...v1.7.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.7.1...v1.7.2)
 
-## [v1.7.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.7.1) (2020-02-01)
+## [v1.7.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.7.1) (2020-02-01)
 
 - Improve `Chart.yaml`.
 - Bump default versions: Puppetserver to `6.8.0`, PostgreSQL to `9.6.16` and PuppetDB to `6.8.1`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.7.0...v1.7.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.7.0...v1.7.1)
 
-## [v1.7.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.7.0) (2020-01-27)
+## [v1.7.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.7.0) (2020-01-27)
 
 - Add support for multiple Puppet Compile Masters.
 - Fix passing extra container environment variables.
 - Indentation improvements.
 - Bump default PuppetDB version to `6.8.0`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.6...v1.7.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.6...v1.7.0)
 
-## [v1.6.6](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.6) (2020-01-09)
+## [v1.6.6](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.6) (2020-01-09)
 
 - Fix outdated r10k exemplary variable in README.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.5...v1.6.6)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.5...v1.6.6)
 
-## [v1.6.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.5) (2020-01-05)
+## [v1.6.5](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.5) (2020-01-05)
 
 - Fixes for Helm packaging.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.4...v1.6.5)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.4...v1.6.5)
 
-## [v1.6.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.4) (2020-01-04)
+## [v1.6.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.4) (2020-01-04)
 
 - Corrections and additional info for use of Ingress resource.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.3...v1.6.4)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.3...v1.6.4)
 
-## [v1.6.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.3) (2020-01-03)
+## [v1.6.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.3) (2020-01-03)
 
 - Allow for using the chart as a chart package.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.2...v1.6.3)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.2...v1.6.3)
 
-## [v1.6.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.2) (2020-01-01)
+## [v1.6.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.2) (2020-01-01)
 
 - Puppetserver Service:
 
 1. Allow for more general way of setting the network protocol.
 2. Improve the way of setting the loadBalancerIP.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.1...v1.6.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.1...v1.6.2)
 
-## [v1.6.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.1) (2019-12-31)
+## [v1.6.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.1) (2019-12-31)
 
 - Add comments in Values file for Puppetserver Service.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.6.0...v1.6.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.6.0...v1.6.1)
 
-## [v1.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.6.0) (2019-12-26)
+## [v1.6.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.6.0) (2019-12-26)
 
 - Add optional affinity for "r10k" pod assignment.
 - File permission fixes for "r10k" jobs' SSH keys.
 - Security fixes for the "r10k" jobs.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.5.3...v1.6.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.5.3...v1.6.0)
 
-## [v1.5.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.5.3) (2019-12-09)
+## [v1.5.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.5.3) (2019-12-09)
 
 - Small README fixes.
 - Add information about the chart in the main [README.md](https://github.com/puppetlabs/pupperware/blob/master/README.md) of Puppetlabs's Pupperware repo.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.5.2...v1.5.3)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.5.2...v1.5.3)
 
-## [v1.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.5.2) (2019-12-06)
+## [v1.5.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.5.2) (2019-12-06)
 
 - Fix PuppetDB usage of pre-generated Puppet SSL certs.
 - Increase deadline time for Puppet pre-install job.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.5.1...v1.5.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.5.1...v1.5.2)
 
-## [v1.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.5.1) (2019-12-03)
+## [v1.5.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.5.1) (2019-12-03)
 
 - Small Indentation Fixes.
 - Use Recommended Dir for PostreSQL's PGDATA.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.5.0...v1.5.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.5.0...v1.5.1)
 
-## [v1.5.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.5.0) (2019-12-02)
+## [v1.5.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.5.0) (2019-12-02)
 
 - Fixes and additions to setting SSH credentials from existing K8s secret.
 - Create separate r10k jobs/schedules for Control Repo and Hiera Data.
@@ -618,46 +623,46 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - General code clean-up.
 - Updates to README.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.4.0...v1.5.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.4.0...v1.5.0)
 
-## [v1.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.4.0) (2019-11-28)
+## [v1.4.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.4.0) (2019-11-28)
 
 - Add optional usage of pre-generated Puppet SSL certificates.
 - Use default path for eYaml keys.
 - Small Values file comment fixes.
 - Code clean-up and lint fixes.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.3.1...v1.4.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.3.1...v1.4.0)
 
-## [v1.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.3.1) (2019-11-25)
+## [v1.3.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.3.1) (2019-11-25)
 
 - Small Values file fix.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.3.0...v1.3.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.3.0...v1.3.1)
 
-## [v1.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.3.0) (2019-11-25)
+## [v1.3.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.3.0) (2019-11-25)
 
 - [Firewall Related] Add support for separate r10k network protocols to gather the code of Puppet and Hiera repos.
 - Increase default r10k sync runtime interval to every 5 minutes.
 - Syntax improvements.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.2.2...v1.3.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.2.2...v1.3.0)
 
-## [v1.2.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.2.2) (2019-11-24)
+## [v1.2.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.2.2) (2019-11-24)
 
 - Fixes <https://github.com/puppetlabs/pupperware/issues/187> and <https://github.com/puppetlabs/pupperware/issues/188.>
 - `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are now owned by Puppet Server.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.2.1...v1.2.2)
 
-## [v1.2.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.2.1) (2019-11-22)
+## [v1.2.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.2.1) (2019-11-22)
 
 - Fixes for "r10k" extra container args.
 - Values file small fixes.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.2.0...v1.2.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.2.0...v1.2.1)
 
-## [v1.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.2.0) (2019-11-21)
+## [v1.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.2.0) (2019-11-21)
 
 - Add optional extra container environment variables.
 - Add optional "r10k" extra container arguments.
@@ -665,21 +670,21 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Small code indentation improvements.
 - README updates.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.1.0...v1.2.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.1.0...v1.2.0)
 
-## [v1.1.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.1.0) (2019-11-19)
+## [v1.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.1.0) (2019-11-19)
 
 - Switch Pulling the Hiera Data Repo from Using "git_sync" to "r10k".
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.0.1...v1.1.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.0.1...v1.1.0)
 
-## [v1.0.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.0.1) (2019-11-11)
+## [v1.0.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.0.1) (2019-11-11)
 
 - Fix Permissions for Hiera, Puppet Server and eYaml Configs.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v1.0.0...v1.0.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v1.0.0...v1.0.1)
 
-## [v1.0.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v1.0.0) (2019-11-08)
+## [v1.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v1.0.0) (2019-11-08)
 
 - Differentiate "nodeSelector" for Pods with Common Storage.
 - Fix for PostgreSQL on AWS.
@@ -687,32 +692,32 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Improve README.
 - Improve Values Comments.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.3.5...v1.0.0)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.3.5...v1.0.0)
 
-## [v0.3.5](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.3.5) (2019-10-31)
+## [v0.3.5](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.3.5) (2019-10-31)
 
 - Add Optional `selector` for PVs/PVCs.
 - Switch to Apache v2.0 License.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.3.4...v0.3.5)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.3.4...v0.3.5)
 
-## [v0.3.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.3.4) (2019-10-28)
+## [v0.3.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.3.4) (2019-10-28)
 
 - Add Ingress.
 - Improve Tmpl Helpers.
 - Improve `NOTES`.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.3.3...v0.3.4)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.3.3...v0.3.4)
 
-## [v0.3.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.3.3) (2019-10-27)
+## [v0.3.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.3.3) (2019-10-27)
 
 - Add Optional Static Data Volumes.
 - Add Configurable PVC's Size.
 - Add Optional PVC's Annotations.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.3.2...v0.3.3)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.3.2...v0.3.3)
 
-## [v0.3.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.3.2) (2019-10-26)
+## [v0.3.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.3.2) (2019-10-26)
 
 - Add optional extra Pod Annotations.
 - Add optional Pod Priority Scheduling.
@@ -721,28 +726,28 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Update README.
 - Fixes.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.3.1...v0.3.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.3.1...v0.3.2)
 
-## [v0.3.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.3.1) (2019-10-24)
+## [v0.3.1](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.3.1) (2019-10-24)
 
 - Add optional "nodeSelector", "affinity" and "tolerations" for Pod Deployments.
 - Improve Values Comments.
 - Bump Component Versions.
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.2.4...v0.3.1)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.2.4...v0.3.1)
 
-## [v0.2.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.2.4) (2019-10-12)
+## [v0.2.4](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.2.4) (2019-10-12)
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.2.3...v0.2.4)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.2.3...v0.2.4)
 
-## [v0.2.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.2.3) (2019-10-11)
+## [v0.2.3](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.2.3) (2019-10-11)
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.2.2...v0.2.3)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.2.2...v0.2.3)
 
-## [v0.2.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.2.2) (2019-10-09)
+## [v0.2.2](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.2.2) (2019-10-09)
 
-[Full Changelog](https://github.com/puppetlabs/puppetserver-helm-chart/compare/v0.2.0...v0.2.2)
+[Full Changelog](https://github.com/OpenVoxProject/openvox-helm-chart/compare/v0.2.0...v0.2.2)
 
-## [v0.2.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v0.2.0) (2019-09-20)
+## [v0.2.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v0.2.0) (2019-09-20)
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: puppetserver
-version: 9.6.0
-appVersion: 7.17.3
-description: Puppet automates the delivery and operation of software.
-keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
+version: 10.0.0
+appVersion: 8.8.0
+description: OpenVox automates the delivery and operation of software.
+keywords: ["OpenVox", "OpenVoxserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/
 icon: https://secure.gravatar.com/avatar/fdd009b7c1ec96e088b389f773e87aec.jpg?s=80&r=g&d=mm
 dependencies:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -713,7 +713,7 @@ If release name contains chart name it will be used as a full name.
 Define puppetdb alternate SAN
 */}}
 {{- define "puppetdb.san" -}}
-{{- $san := printf "puppetdb,%s" ( include "puppetdb.fullname" . ) -}}
+{{- $san := printf "openvoxdb,puppetdb,%s" ( include "puppetdb.fullname" . ) -}}
 {{- if .Values.puppetdb.fqdns.alternateServerNames -}}
 {{- $san = print $san "," .Values.puppetdb.fqdns.alternateServerNames -}}
 {{- end -}}
@@ -737,8 +737,8 @@ Return PostgreSQL host name
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}
-{{- else if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME }}
-{{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
+{{- else if .Values.puppetdb.extraEnv.OPENVOXDB_POSTGRES_HOSTNAME }}
+{{- printf "%s" .Values.puppetdb.extraEnv.OPENVOXDB_POSTGRES_HOSTNAME -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -106,22 +106,22 @@ spec:
           resources:
             {{- toYaml .Values.puppetdb.resources | nindent 12 }}
           env:
-            - name: PUPPETSERVER_HOSTNAME
+            - name: OPENVOXSERVER_HOSTNAME
               value: {{ template "puppetserver.puppetserver-masters.serviceName" . }}
-            - name: PUPPETSERVER_PORT
+            - name: OPENVOXSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
               value: {{ template "puppetdb.san" . }}
-            {{- if not (hasKey .Values.puppetdb.extraEnv "PUPPETDB_POSTGRES_HOSTNAME") }}
-            - name: PUPPETDB_POSTGRES_HOSTNAME
+            {{- if not (hasKey .Values.puppetdb.extraEnv "OPENVOXDB_POSTGRES_HOSTNAME") }}
+            - name: OPENVOXDB_POSTGRES_HOSTNAME
               value: "{{ include "postgresql.hostname" . }}"
             {{- end }}
-            - name: PUPPETDB_PASSWORD
+            - name: OPENVOXDB_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "puppetdb.secret" . }}
                   key: password
-            - name: PUPPETDB_USER
+            - name: OPENVOXDB_POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "puppetdb.secret" . }}
@@ -180,9 +180,9 @@ spec:
             - name: PUPPETDB_SSL_VERIFY
               value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem"
             - name: PUPPETDB_CERT
-              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/puppetdb.pem"
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/openvoxdb.pem"
             - name: PUPPETDB_KEY
-              value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/puppetdb.pem"
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/openvoxdb.pem"
             - name: PUPPETBOARD_PORT
               value: {{ .Values.puppetboard.port | quote }}
             - name: SECRET_KEY
@@ -282,9 +282,9 @@ spec:
             - name: PUPPETDB_URL
               value: "https://{{ if .Values.singleCA.enabled}}{{.Values.singleCA.puppetdb.overrideHostname}}{{ else }}{{ ( include "puppetdb.fullname" . ) }}{{ end }}:8081/pdb/query"
             - name: PUPPETDB_CERT_FILE
-              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/puppetdb.pem"
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/openvoxdb.pem"
             - name: PUPPETDB_KEY_FILE
-              value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/puppetdb.pem"
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/openvoxdb.pem"
             - name: PUPPETDB_CA_FILE
               value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem"
             - name: PUPPETDB_SCRAPE_INTERVAL

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -216,22 +216,22 @@ spec:
             # puppetserver ca cli application
             {{- if .Values.singleCA.enabled }}
               # set the hostname to puppet to identify easily the certificate
-            - name: PUPPETSERVER_HOSTNAME
+            - name: OPENVOXSERVER_HOSTNAME
               value: puppet
             {{- end }}
-            - name: PUPPET_MASTERPORT
+            - name: OPENVOXSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
               value: "puppet,{{ template "puppetserver.puppetserver.agents-to-masters.serviceName" . }},{{ template "puppetserver.puppetserver-masters.serviceName" . }},{{.Values.puppetserver.masters.fqdns.alternateServerNames}},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
-            - name: PUPPETDB_SERVER_URLS
-              value: "https://{{ default ( include "puppetdb.fullname" . ) .Values.singleCA.puppetdb.overrideHostname }}:8081"
+            - name: OPENVOXDB_SERVER_URLS
+              value: https://{{ if .Values.singleCA.enabled}}{{.Values.singleCA.puppetdb.overrideHostname}}{{else }}{{ ( include "puppetdb.fullname" . ) }}{{end}}:8081
             - name: CA_ENABLED
               value: "false"
             - name: CA_ALLOW_SUBJECT_ALT_NAMES
               value: "true"
             - name: CA_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
-            - name: CA_MASTERPORT
+            - name: CA_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             {{- end }}
             {{- range $key, $value := .Values.global.extraEnv }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -239,7 +239,7 @@ spec:
           {{- end }}
           env:
             {{- if not .Values.global.runAsNonRoot }}
-            - name: PUPPETSERVER_HOSTNAME
+            - name: OPENVOXSERVER_HOSTNAME
               value: puppet
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
@@ -248,12 +248,12 @@ spec:
               value: "false"
               # set the hostname to puppet to identify easily the certificate
             {{- end }}
-            - name: PUPPET_MASTERPORT
+            - name: OPENVOXSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.master.san" . }}"
-            - name: PUPPETDB_SERVER_URLS
-              value: "https://{{ default ( include "puppetdb.fullname" . ) .Values.singleCA.puppetdb.overrideHostname }}:8081"
+            - name: OPENVOXDB_SERVER_URLS
+              value: https://{{ if .Values.singleCA.enabled}}{{.Values.singleCA.puppetdb.overrideHostname}}{{else }}{{ ( include "puppetdb.fullname" . ) }}{{end}}:8081
             - name: CA_ALLOW_SUBJECT_ALT_NAMES
               value: "true"
             {{- end }}

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -210,7 +210,7 @@ spec:
           resources:
             {{- toYaml .Values.puppetserver.compilers.resources | nindent 12 }}
           env:
-            - name: PUPPETSERVER_HOSTNAME
+            - name: OPENVOXSERVER_HOSTNAME
             {{- if .Values.singleCA.enabled }}
               value: {{ (include "puppetserver.puppetserver-masters.serviceName" . | quote ) }}
             {{- else }}
@@ -218,17 +218,17 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- end }}
-            - name: PUPPET_MASTERPORT
+            - name: OPENVOXSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-compilers.port" . }}"
             - name: DNS_ALT_NAMES
               value: "{{ template "puppetserver.compilers.hostnames" . }},{{ template "puppetserver.puppetserver-compilers.serviceName" . }},{{.Values.puppetserver.compilers.fqdns.alternateServerNames}}"
-            - name: PUPPETDB_SERVER_URLS
+            - name: OPENVOXDB_SERVER_URLS
               value: https://{{ if .Values.singleCA.enabled}}{{.Values.singleCA.puppetdb.overrideHostname}}{{else }}{{ ( include "puppetdb.fullname" . ) }}{{end}}:8081
             - name: CA_ENABLED
               value: "false"
             - name: CA_HOSTNAME
               value: "{{ template "puppetserver.puppetserver-masters.serviceName" . }}"
-            - name: CA_MASTERPORT
+            - name: CA_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             {{- range $key, $value := .Values.global.extraEnv }}
             - name: {{ $key }}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -30,8 +30,8 @@ manifest should match snapshot:
             app.kubernetes.io/instance: puppetserver
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
-            app.kubernetes.io/version: 7.17.3
-            helm.sh/chart: puppetserver-9.6.0
+            app.kubernetes.io/version: 8.8.0
+            helm.sh/chart: puppetserver-10.0.0
         spec:
           containers:
             - env:
@@ -50,7 +50,7 @@ manifest should match snapshot:
                 - name: CA_MASTERPORT
                   value: "8140"
               envFrom: null
-              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
+              image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -114,7 +114,7 @@ manifest should match snapshot:
                 - -c
               env: null
               envFrom: null
-              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
+              image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main
               imagePullPolicy: IfNotPresent
               name: perms-and-dirs
               resources:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -35,11 +35,11 @@ manifest should match snapshot:
         spec:
           containers:
             - env:
-                - name: PUPPET_MASTERPORT
+                - name: OPENVOXSERVER_PORT
                   value: "8140"
                 - name: DNS_ALT_NAMES
                   value: puppet,puppetserver-agents-to-puppet,puppetserver-puppet,,puppetserver-puppet-compilers,
-                - name: PUPPETDB_SERVER_URLS
+                - name: OPENVOXDB_SERVER_URLS
                   value: https://puppetserver-puppetdb:8081
                 - name: CA_ENABLED
                   value: "false"
@@ -47,7 +47,7 @@ manifest should match snapshot:
                   value: "true"
                 - name: CA_HOSTNAME
                   value: puppetserver-puppet
-                - name: CA_MASTERPORT
+                - name: CA_PORT
                   value: "8140"
               envFrom: null
               image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -31,8 +31,8 @@ manifest should match snapshot:
             app.kubernetes.io/instance: puppetserver
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
-            app.kubernetes.io/version: 7.17.3
-            helm.sh/chart: puppetserver-9.6.0
+            app.kubernetes.io/version: 8.8.0
+            helm.sh/chart: puppetserver-10.0.0
         spec:
           containers:
             - env:
@@ -53,7 +53,7 @@ manifest should match snapshot:
                 - name: CA_MASTERPORT
                   value: "8140"
               envFrom: null
-              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
+              image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -112,7 +112,7 @@ manifest should match snapshot:
                 - -c
               env: null
               envFrom: null
-              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
+              image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main
               imagePullPolicy: IfNotPresent
               name: perms-and-dirs
               resources:

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -36,21 +36,21 @@ manifest should match snapshot:
         spec:
           containers:
             - env:
-                - name: PUPPETSERVER_HOSTNAME
+                - name: OPENVOXSERVER_HOSTNAME
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                - name: PUPPET_MASTERPORT
+                - name: OPENVOXSERVER_PORT
                   value: "8140"
                 - name: DNS_ALT_NAMES
                   value: puppetserver-puppetserver-compiler-0,puppetserver-puppet-compilers,
-                - name: PUPPETDB_SERVER_URLS
+                - name: OPENVOXDB_SERVER_URLS
                   value: https://puppetserver-puppetdb:8081
                 - name: CA_ENABLED
                   value: "false"
                 - name: CA_HOSTNAME
                   value: puppetserver-puppet
-                - name: CA_MASTERPORT
+                - name: CA_PORT
                   value: "8140"
               envFrom: null
               image: ghcr.io/openvoxproject/openvoxserver:8.8.0-main

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.3
-        helm.sh/chart: puppetserver-9.6.0
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.0
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -63,8 +63,8 @@ global:
 ##
 puppetserver:
   name: puppetserver
-  image: ghcr.io/voxpupuli/puppetserver
-  tag: 7.17.3-main
+  image: ghcr.io/openvoxproject/openvoxserver
+  tag: 8.8.0-main
   pullPolicy: IfNotPresent
 
   ## Configure persistence for Puppet Server
@@ -765,8 +765,8 @@ r10k:
 puppetdb:
   enabled: true
   name: puppetdb
-  image: voxpupuli/puppetdb
-  tag: 7.20.0-main
+  image: ghcr.io/openvoxproject/openvoxdb
+  tag: 8.9.0-main
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:


### PR DESCRIPTION
This is a BREAKING change

bumped major version to 10.0.0, you cannot (reliably) use the legacy puppet containers images with this only openvox

Various environment variables had to change under the hood which forces this issue.

Previous config values are still valid at this stage to be later updated to new naming.

Also bumped Major version of Server/DB from 7.x to 8.x at this point

I do NOT recommend trying to switch/migrate your deployment from the legacy puppetserver chart to this - it is possible but does seem to be rather finnicky and require various potential manual interventions - i recommend backing up your CA certs then deploying clean charts/containers and restore your CA into the new deployment