### PR TITLE
add nodeselector/affinity/tolerations/capabilities to separate r10k deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v10.1.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v10.1.0) (2026-01-15)
+- Feat: Add affinity, nodeSelector, tolerations, and priorityClassName to r10k deployment
+- Fix: Change puppetmaster deplyoment affinity to use template which includes antiaffinity rules for multimasters
+- Fix: Cosmetic whitespace fixes
+
 ## [v10.0.0](https://github.com/OpenVoxProject/openvox-helm-chart/tree/v10.0.0) (2025-03-19)
 - Feat: Switch to OpenVox Containers
 - Feat: Default to Openvox v8 of OpenVox-server and OpenVoxDB

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -278,7 +278,7 @@ spec:
         {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.affinity | nindent 10 }}
+        {{ toYaml .Values.nodeSelector | nindent 10 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -276,4 +276,19 @@ spec:
           secret:
             secretName: {{ $extraSecret.name }}
         {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             {{- range .Values.r10k.code.command }}
             - {{ . | quote }}
-            {{- end}}
+            {{- end }}
           args:
             {{- range .Values.r10k.code.args }}
             - {{ . | quote }}
@@ -164,7 +164,7 @@ spec:
             - name: r10k-hiera-volume
               mountPath: /etc/puppetlabs/puppet/r10k_hiera.yaml
               subPath: r10k_hiera.yaml
-            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
+            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/eyaml/keys
             {{- end }}
@@ -265,7 +265,7 @@ spec:
         - name: eyamlpriv-volume
           secret:
             secretName: {{ template "puppetserver.hiera.privateSecret" . }}
-        {{- else if .Values.hiera.eyaml.existingMap  }}
+        {{- else if .Values.hiera.eyaml.existingMap }}
         - name: eyaml-volume
           configMap:
             name: {{ .Values.hiera.eyaml.existingMap }}
@@ -276,4 +276,19 @@ spec:
           secret:
             secretName: {{ $extraSecret.name }}
         {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 10 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 10 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | nindent 10 }}
+      {{- end }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -164,7 +164,7 @@ spec:
             - name: r10k-hiera-volume
               mountPath: /etc/puppetlabs/puppet/r10k_hiera.yaml
               subPath: r10k_hiera.yaml
-            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key)  }}
+            {{- if and (or (.Values.hiera.eyaml.existingMap) (.Values.hiera.eyaml.existingSecret)) (not .Values.hiera.eyaml.public_key) (not .Values.hiera.eyaml.private_key) }}
             - name: eyaml-volume
               mountPath: /etc/puppetlabs/puppet/eyaml/keys
             {{- end }}
@@ -265,7 +265,7 @@ spec:
         - name: eyamlpriv-volume
           secret:
             secretName: {{ template "puppetserver.hiera.privateSecret" . }}
-        {{- else if .Values.hiera.eyaml.existingMap  }}
+        {{- else if .Values.hiera.eyaml.existingMap }}
         - name: eyaml-volume
           configMap:
             name: {{ .Values.hiera.eyaml.existingMap }}

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             {{- range .Values.r10k.code.command }}
             - {{ . | quote }}
-            {{- end}}
+            {{- end }}
           args:
             {{- range .Values.r10k.code.args }}
             - {{ . | quote }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -362,7 +362,7 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-        {{ toYaml .Values.tolerations| nindent 10 }}
+        {{ toYaml .Values.tolerations | nindent 10 }}
       {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -413,7 +413,7 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-        {{ toYaml .Values.tolerations| nindent 10 }}
+        {{ toYaml .Values.tolerations | nindent 10 }}
       {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -712,7 +712,7 @@ spec:
       {{ template "puppetserver.compilers.affinity" . }}
       {{- if .Values.tolerations }}
       tolerations:
-        {{ toYaml .Values.tolerations| nindent 10 }}
+        {{ toYaml .Values.tolerations | nindent 10 }}
       {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -756,7 +756,7 @@ spec:
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}
       {{- end }}
-      { template "puppetserver.masters.affinity" . }}
+      {{ template "puppetserver.masters.affinity" . }}
       {{- if .Values.tolerations }}
       tolerations:
         {{ toYaml .Values.tolerations | nindent 10 }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -756,13 +756,10 @@ spec:
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}
       {{- end }}
-      {{- if .Values.affinity }}
-      affinity:
-      {{ toYaml .Values.affinity | nindent 10 }}
-      {{- end }}
+      { template "puppetserver.masters.affinity" . }}
       {{- if .Values.tolerations }}
       tolerations:
-        {{ toYaml .Values.tolerations| nindent 10 }}
+        {{ toYaml .Values.tolerations | nindent 10 }}
       {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -756,13 +756,10 @@ spec:
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}
       {{- end }}
-      {{- if .Values.affinity }}
-      affinity:
-      {{ toYaml .Values.affinity | nindent 10 }}
-      {{- end }}
+      {{ template "puppetserver.masters.affinity" . }}
       {{- if .Values.tolerations }}
       tolerations:
-        {{ toYaml .Values.tolerations| nindent 10 }}
+        {{ toYaml .Values.tolerations | nindent 10 }}
       {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1beta1") (.Values.priorityClassName) }}
       priorityClassName: {{ .Values.priorityClassName }}


### PR DESCRIPTION
add nodeselector/affinity/tolerations/capabilities to separate r10k deployment
fix | (pipe) spacing
move puppetserver.masters.affinity to template like puppetserver.compilers.affinity