### PR TITLE
feat: add OpenVox View dashboard alongside Puppetboard

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 10.0.2
+version: 10.0.3
 appVersion: 8.8.0
 description: OpenVox automates the delivery and operation of software.
 keywords: ["OpenVox", "OpenVoxserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -501,6 +501,21 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetboard.ingress.extraLabels`| puppetboard ingress extraLabels |``|
 | `puppetboard.ingress.hosts`| puppetboard ingress hostnames |``|
 | `puppetboard.ingress.tls`| puppetboard ingress tls configuration |``|
+| `openvoxview.enabled` | OpenVox View availability | `false`|
+| `openvoxview.name` | OpenVox View component label | `openvoxview`|
+| `openvoxview.image` | OpenVox View image | `ghcr.io/voxpupuli/openvoxview`|
+| `openvoxview.tag` | OpenVox View image tag | `latest`|
+| `openvoxview.port` | OpenVox View container port | `5000`|
+| `openvoxview.pullPolicy` | OpenVox View image pull policy | `IfNotPresent`|
+| `openvoxview.resources` | OpenVox View resource limits |``|
+| `openvoxview.extraEnv` | OpenVox View additional container env vars |``|
+| `openvoxview.extraEnvSecret` | OpenVox View additional container env vars from pre-existing secret |``|
+| `openvoxview.service.targetPort` | target port for the OpenVox View service port |`openvoxview`|
+| `openvoxview.ingress.enabled`| OpenVox View ingress creation enabled |`false`|
+| `openvoxview.ingress.annotations`| OpenVox View ingress annotations |``|
+| `openvoxview.ingress.extraLabels`| OpenVox View ingress extraLabels |``|
+| `openvoxview.ingress.hosts`| OpenVox View ingress hostnames |``|
+| `openvoxview.ingress.tls`| OpenVox View ingress tls configuration |``|
 | `hiera.name` | hiera component label | `hiera`|
 | `hiera.hieradataurl`| hieradata repo url |``|
 | `hiera.config`| hieradata yaml config |``|
@@ -620,6 +635,27 @@ jobs | grep 'port-forward' | grep 'puppetserver'
 # [1]+  Running                 kubectl port-forward -n puppetserver svc/puppet 8140:8140 &
 kill %[job_numbers_above]
 ```
+
+### Example: Enabling OpenVox View
+
+To enable the OpenVox View dashboard as a sidecar on the PuppetDB pod, you can use a values file similar to:
+
+```yaml
+openvoxview:
+  enabled: true
+  image: ghcr.io/voxpupuli/openvoxview
+  tag: latest
+  port: 5000
+  ingress:
+    enabled: true
+    hosts:
+      - openvoxview.example.com
+
+puppetboard:
+  enabled: false
+```
+
+You can also enable both dashboards at the same time by setting both `openvoxview.enabled` and `puppetboard.enabled` to `true` and configuring distinct ingress hosts or paths.
 
 ## Credits
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -123,6 +123,16 @@ app.kubernetes.io/component: {{ .Values.puppetboard.name }}
 {{ include "puppetserver.common.matchLabels" . }}
 {{- end -}}
 
+{{- define "puppetserver.openvoxview.labels" -}}
+{{ include "puppetserver.openvoxview.matchLabels" . }}
+{{ include "puppetserver.common.metaLabels" . }}
+{{- end -}}
+
+{{- define "puppetserver.openvoxview.matchLabels" -}}
+app.kubernetes.io/component: {{ .Values.openvoxview.name }}
+{{ include "puppetserver.common.matchLabels" . }}
+{{- end -}}
+
 {{- define "puppetserver.puppetserver.labels" -}}
 {{ include "puppetserver.puppetserver.matchLabels" . }}
 {{ include "puppetserver.common.metaLabels" . }}

--- a/templates/openvoxview-ingress.yaml
+++ b/templates/openvoxview-ingress.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.openvoxview.enabled .Values.openvoxview.ingress.enabled }}
+{{- $releaseName := .Release.Name -}}
+{{- $serviceName := ( include "puppetdb.fullname" . ) }}
+{{- $servicePort := .Values.openvoxview.port -}}
+{{- $pathType := .Values.openvoxview.ingress.pathType | default "ImplementationSpecific" -}}
+{{- $apiIsStable := eq (include "puppetserver.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "puppetserver.ingress.supportsPathType" .) "true" -}}
+apiVersion: {{ include "puppetserver.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  {{- if .Values.openvoxview.ingress.annotations }}
+  annotations:
+    {{ toYaml .Values.openvoxview.ingress.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "puppetserver.puppetdb.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.openvoxview.ingress.extraLabels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  name: {{ template "puppetdb.fullname" . }}-openvoxview
+spec:
+  {{- if $apiIsStable }}
+  {{- if .Values.openvoxview.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.openvoxview.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.openvoxview.ingress.hosts }}
+    {{- $url := splitList "/" . }}
+    - host: {{ first $url }}
+      http:
+        paths:
+          - path: {{ if gt (len $url) 1 }}{{ printf "/%s" (join "/" (rest $url)) }}{{ else }} / {{ end }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $pathType }}
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+    {{- end -}}
+  {{- if .Values.openvoxview.ingress.tls }}
+  tls:
+    {{ toYaml .Values.openvoxview.ingress.tls | nindent 4 }}
+  {{- end -}}
+{{- end -}}
+

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -218,6 +218,57 @@ spec:
             - name: puppetdb-storage
               mountPath: /opt/puppetlabs/server/data/puppetdb
         {{- end }}
+        {{- if .Values.openvoxview.enabled }}
+        - name: openvoxview
+          image: "{{.Values.openvoxview.image}}:{{.Values.openvoxview.tag}}"
+          imagePullPolicy: "{{.Values.openvoxview.pullPolicy}}"
+          resources:
+            {{- toYaml .Values.openvoxview.resources | nindent 12 }}
+          env:
+            - name: LISTEN
+              value: "0.0.0.0"
+            - name: PORT
+              value: {{ .Values.openvoxview.port | quote }}
+            - name: PUPPETDB_HOST
+              value: {{ if .Values.singleCA.enabled}}{{.Values.singleCA.puppetdb.overrideHostname}}{{ else }}{{ ( include "puppetdb.fullname" . ) }}{{ end }}
+            - name: PUPPETDB_PORT
+              value: "8081"
+            - name: PUPPETDB_TLS
+              value: "true"
+            - name: PUPPETDB_TLS_CA
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem"
+            - name: PUPPETDB_TLS_KEY
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/private_keys/openvoxdb.pem"
+            - name: PUPPETDB_TLS_CERT
+              value: "/opt/puppetlabs/server/data/puppetdb/certs/certs/openvoxdb.pem"
+            {{- range $key, $value := .Values.global.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            {{- range $key, $value := .Values.openvoxview.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          envFrom:
+          {{- if .Values.global.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.global.extraEnvSecret }}
+          {{- end }}
+          {{- if .Values.openvoxview.extraEnvSecret }}
+            - secretRef:
+                name: {{ .Values.openvoxview.extraEnvSecret }}
+          {{- end }}
+          ports:
+            - name: openvoxview
+              containerPort: {{ .Values.openvoxview.port }}
+          securityContext:
+            {{- toYaml .Values.openvoxview.securityContext | nindent 12 }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.global.securityContext.runAsGroup }}
+          volumeMounts:
+            - name: puppetdb-storage
+              mountPath: /opt/puppetlabs/server/data/puppetdb
+        {{- end }}
         {{- if and .Values.singleCA.enabled .Values.singleCA.crl.asSidecar }}
         # singleCA crl script update Sidecar
         - name: update-crl

--- a/templates/puppetdb-service.yaml
+++ b/templates/puppetdb-service.yaml
@@ -25,6 +25,11 @@ spec:
       port: {{ .Values.puppetboard.port }}
       targetPort: {{ .Values.puppetboard.service.targetPort }}
     {{- end }}
+    {{- if .Values.openvoxview.enabled }}
+    - name: openvoxview
+      port: {{ .Values.openvoxview.port }}
+      targetPort: {{ .Values.openvoxview.service.targetPort }}
+    {{- end }}
     {{- if .Values.metrics.prometheus.enabled }}
     - name: metrics
       port: {{ .Values.metrics.prometheus.port }}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/openvoxview-ingress_test.yaml.snap
+++ b/tests/__snapshot__/openvoxview-ingress_test.yaml.snap
@@ -1,0 +1,22 @@
+should create openvoxview ingress when enabled:
+  1: |
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      labels:
+        app.kubernetes.io/component: puppetdb
+        app.kubernetes.io/instance: puppetserver
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: puppetserver
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.3
+      name: puppetserver-puppetdb-openvoxview
+    spec:
+      rules:
+        - host: openvoxview.example.com
+          http:
+            paths:
+              - backend:
+                  serviceName: puppetserver-puppetdb
+                  servicePort: 5000
+                path: /

--- a/tests/__snapshot__/puppetdb-deployment.openvoxview_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-deployment.openvoxview_test.yaml.snap
@@ -1,0 +1,173 @@
+should include openvoxview sidecar when enabled:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: puppetdb
+        app.kubernetes.io/instance: puppetserver
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: puppetserver
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.3
+      name: puppetserver-puppetdb
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: puppetdb
+          app.kubernetes.io/name: puppetserver
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app.kubernetes.io/component: puppetdb
+            app.kubernetes.io/instance: puppetserver
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: puppetserver
+            app.kubernetes.io/version: 8.8.0
+            helm.sh/chart: puppetserver-10.0.3
+        spec:
+          containers:
+            - env:
+                - name: OPENVOXSERVER_HOSTNAME
+                  value: puppetserver-puppet
+                - name: OPENVOXSERVER_PORT
+                  value: "8140"
+                - name: DNS_ALT_NAMES
+                  value: openvoxdb,puppetdb,puppetserver-puppetdb
+                - name: OPENVOXDB_POSTGRES_HOSTNAME
+                  value: puppetserver-postgresql-hl
+                - name: OPENVOXDB_POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: puppetserver-puppetdb-postgresql
+                - name: OPENVOXDB_POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: puppetserver-puppetdb-postgresql
+                - name: PUPPETDB_JAVA_ARGS
+                  value: ""
+              envFrom: null
+              image: ghcr.io/openvoxproject/openvoxdb:8.9.0-main
+              imagePullPolicy: IfNotPresent
+              name: puppetdb
+              ports:
+                - containerPort: 8080
+                  name: pdb-http
+                - containerPort: 8081
+                  name: pdb-https
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  add:
+                    - CAP_FOWNER
+                    - CAP_CHOWN
+                    - CAP_SETUID
+                    - CAP_SETGID
+                    - CAP_DAC_OVERRIDE
+                    - FOWNER
+                    - CHOWN
+                    - SETUID
+                    - SETGID
+                    - DAC_OVERRIDE
+                  drop:
+                    - all
+              volumeMounts:
+                - mountPath: /opt/puppetlabs/server/data/puppetdb
+                  name: puppetdb-storage
+            - env:
+                - name: LISTEN
+                  value: 0.0.0.0
+                - name: PORT
+                  value: "5000"
+                - name: PUPPETDB_HOST
+                  value: puppetserver-puppetdb
+                - name: PUPPETDB_PORT
+                  value: "8081"
+                - name: PUPPETDB_TLS
+                  value: "true"
+                - name: PUPPETDB_TLS_CA
+                  value: /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
+                - name: PUPPETDB_TLS_KEY
+                  value: /opt/puppetlabs/server/data/puppetdb/certs/private_keys/openvoxdb.pem
+                - name: PUPPETDB_TLS_CERT
+                  value: /opt/puppetlabs/server/data/puppetdb/certs/certs/openvoxdb.pem
+              envFrom: null
+              image: ghcr.io/voxpupuli/openvoxview:v1.3.0
+              imagePullPolicy: IfNotPresent
+              name: openvoxview
+              ports:
+                - containerPort: 5000
+                  name: openvoxview
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - all
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              volumeMounts:
+                - mountPath: /opt/puppetlabs/server/data/puppetdb
+                  name: puppetdb-storage
+          hostname: puppetdb
+          imagePullSecrets: null
+          initContainers:
+            - command:
+                - sh
+                - -c
+                - |
+                  echo 'Waiting for PostgreSQL to become ready...'
+                  until printf "." && nc -z -w 2 puppetserver-postgresql-hl 5432; do
+                      sleep 2;
+                  done;
+                  echo 'PostgreSQL OK ✓'
+              image: docker.io/busybox:1.37
+              imagePullPolicy: IfNotPresent
+              name: pgchecker
+              resources:
+                limits:
+                  cpu: 20m
+                  memory: 32Mi
+                requests:
+                  cpu: 20m
+                  memory: 32Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+            - command:
+                - sh
+                - -c
+                - |
+                  echo 'Waiting for puppetserver to become ready...'
+                  until printf "." && curl --silent --fail --insecure 'https://puppetserver-puppet:8140/status/v1/simple' | grep -q '^running$'; do
+                    sleep 2;
+                  done;
+                  echo 'Puppetserver OK ✓'
+              image: curlimages/curl:8.11.1
+              imagePullPolicy: IfNotPresent
+              name: wait-puppetserver
+              resources:
+                limits:
+                  cpu: 20m
+                  memory: 32Mi
+                requests:
+                  cpu: 20m
+                  memory: 32Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+          volumes:
+            - name: puppetdb-storage
+              persistentVolumeClaim:
+                claimName: puppetserver-puppetdb-claim

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-service.openvoxview_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-service.openvoxview_test.yaml.snap
@@ -1,0 +1,28 @@
+should expose openvoxview port when enabled:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: puppetdb
+        app.kubernetes.io/instance: puppetserver
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: puppetserver
+        app.kubernetes.io/version: 8.8.0
+        helm.sh/chart: puppetserver-10.0.3
+      name: puppetserver-puppetdb
+    spec:
+      ports:
+        - name: pdb-http
+          port: 8080
+          targetPort: pdb-http
+        - name: pdb-https
+          port: 8081
+          targetPort: pdb-https
+        - name: openvoxview
+          port: 5000
+          targetPort: openvoxview
+      selector:
+        app.kubernetes.io/component: puppetdb
+        app.kubernetes.io/name: puppetserver
+      type: ClusterIP

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 8.8.0
-            helm.sh/chart: puppetserver-10.0.2
+            helm.sh/chart: puppetserver-10.0.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 8.8.0
-            helm.sh/chart: puppetserver-10.0.2
+            helm.sh/chart: puppetserver-10.0.3
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.8.0
-        helm.sh/chart: puppetserver-10.0.2
+        helm.sh/chart: puppetserver-10.0.3
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/tests/openvoxview-ingress_test.yaml
+++ b/tests/openvoxview-ingress_test.yaml
@@ -1,0 +1,25 @@
+suite: test openvoxview ingress creation
+templates:
+  - openvoxview-ingress.yaml
+release:
+  name: puppetserver
+  namespace: puppet
+tests:
+  - it: should not create the openvoxview ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create openvoxview ingress when enabled
+    set:
+      openvoxview.enabled: true
+      openvoxview.ingress.enabled: true
+      openvoxview.ingress.hosts:
+        - openvoxview.example.com
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: puppetserver-puppetdb-openvoxview
+      - matchSnapshot: {}

--- a/tests/puppetdb-deployment.openvoxview_test.yaml
+++ b/tests/puppetdb-deployment.openvoxview_test.yaml
@@ -1,0 +1,14 @@
+suite: test puppetdb deployment openvoxview integration
+templates:
+  - puppetdb-deployment.yaml
+release:
+  name: puppetserver
+  namespace: puppet
+tests:
+  - it: should include openvoxview sidecar when enabled
+    set:
+      openvoxview.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchSnapshot: {}

--- a/tests/puppetdb-service.openvoxview_test.yaml
+++ b/tests/puppetdb-service.openvoxview_test.yaml
@@ -1,0 +1,14 @@
+suite: test puppetdb service openvoxview port
+templates:
+  - puppetdb-service.yaml
+release:
+  name: puppetserver
+  namespace: puppet
+tests:
+  - it: should expose openvoxview port when enabled
+    set:
+      openvoxview.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - matchSnapshot: {}

--- a/values.yaml
+++ b/values.yaml
@@ -985,6 +985,61 @@ puppetboard:
     #     hosts:
     #       - puppetboard.domain.com
 
+## OpenVox View Configuration
+##
+openvoxview:
+  enabled: false
+  name: openvoxview
+  image: ghcr.io/voxpupuli/openvoxview
+  tag: v1.3.0
+  port: 5000
+  pullPolicy: IfNotPresent
+  service:
+    targetPort: openvoxview
+  resources: {}
+  #  requests:
+  #    memory: 256Mi
+  #    cpu: 200m
+  #  limits:
+  #    memory: 512Mi
+  #    cpu: 500m
+  ## Additional OpenVox View container environment variables
+  ## (these are merged on top of the defaults set by the chart)
+  ##
+  extraEnv: {}
+  ## Additional OpenVox View container environment variables from a pre-existing K8s secret
+  extraEnvSecret: ""
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
+  ingress:
+    ## If true, OpenVox View Ingress will be created
+    ##
+    enabled: false
+    ## OpenVox View Ingress annotations
+    ##
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+    ## OpenVox View Ingress additional labels
+    ##
+    extraLabels: {}
+    ## OpenVox View Ingress hostnames with optional path
+    ## Must be provided if Ingress is enabled
+    ##
+    hosts: []
+    #   - openvoxview.domain.com
+    #   - domain.com/openvoxview
+    ## OpenVox View Ingress TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    tls: []
+    #   - secretName: openvoxview-server-tls
+    #     hosts:
+    #       - openvoxview.domain.com
+
 ## Hiera Configuration for Puppet Server
 ##
 hiera:


### PR DESCRIPTION
Fixes #19 

Summary

- Adds OpenVox View support to openvox-helm-chart as an additional optional dashboard (Option B), without removing existing Puppetboard support.
- Introduces openvoxview.* values (image/tag/port/resources/env/ingress/securityContext) to enable/disable OpenVox View independently.
- Deploys OpenVox View as a sidecar container in the PuppetDB pod, mounts PuppetDB certs, and exposes it via the PuppetDB service on port 5000.
- Adds an optional openvoxview ingress template and helper labels.
- Updates README with configuration and usage examples.








---
*PR sponsored by [Obmondo.com](https://obmondo.com)*

---

**Note:** Since this is a company-paid contribution, we fork to the company account repo on GitHub. GitHub does not support "allow maintainer to edit in repo" for organization accounts.

- Maintainers can either provide feedback for required changes before merging, OR
- Pull our branch, make changes in their repo, and create a new PR including our commits.