### PR TITLE
Various Release/Workflow plumbing items

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+---
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - modulesync
+      - question
+      - skip-changelog
+      - wont-fix
+      - wontfix
+      - github_actions
+
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - backwards-incompatible
+
+    - title: New Features 🎉
+      labels:
+        - enhancement
+
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+
+    - title: Documentation Updates 📚
+      labels:
+        - documentation
+        - docs
+
+    - title: Dependency Updates ⬆️
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+---
+name: 🚦 CI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Lint and Build Helm chart
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+          check-latest: true
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run helm unit tests
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          helm unittest ./
+
+      - name: Create testing cluster
+        uses: helm/kind-action@v1.14.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --charts ./
+
+      - name: Run chart-testing (install)
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts ./
+        

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,10 @@
+name: PR Testing
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml  # use the callable tests job to run tests 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,42 +1,12 @@
-name: CI / Release
+name: Release
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:
   test:
-    name: Lint and Build Helm chart
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          check-latest: true
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.0
-
-      - name: Run helm unit tests
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git
-          helm unittest ./
-
-      - name: Create testing cluster
-        uses: helm/kind-action@v1.8.0
-
-      - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --charts ./
-
-      - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --charts ./
-        
+    uses: ./.github/workflows/ci.yml  # use the callable tests job to run tests
+       
   publish:
     name: Publish Helm chart
     runs-on: ubuntu-latest
@@ -47,7 +17,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Fetch history
         run: git fetch --prune --unshallow
       - name: Install Helm
@@ -63,29 +33,14 @@ jobs:
       - name: Package the chart
         run: helm package . --destination .release-packages --dependency-update
 
-      - name: Prep release notes
-        run: |
-          release_notes=`sed -n '/^## \['v${{ env.VERSION }}'\]/,/^## /p' CHANGELOG.md | sed -n '/^- /p'`
-          echo "RELEASE NOTES: $release_notes"
-          echo "$release_notes" > body.md
-          release_name=`echo "$release_notes"| head -1 | sed 's/^- //'`
-          echo "RELEASE_NAME=$release_name" >> $GITHUB_ENV
-
       - name: Make the release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2.6.1
         with:
+          generate_release_notes: true
           tag_name: v${{ env.VERSION }}
-          release_name: ${{ env.RELEASE_NAME }}
-          body_path: body.md
-
-      - name: upload artifacts to the release
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./.release-packages/puppetserver-${{ env.VERSION }}.tgz
-          asset_name: puppetserver-${{ env.VERSION }}.tgz
-          asset_content_type: application/gzip
+          name: v${{ env.VERSION }}
+          files: ./.release-packages/puppetserver-${{ env.VERSION }}.tgz
 
       - name: update ghpages
         run: |


### PR DESCRIPTION
Fixes #23 

A number of small changes to optimise  workflows and also to ideally align with how things are done within other repos within the project more generally - this will also simplify requirements for PR creators. e.g. not manually bumping the version and test versions for every single PR only for a release PR that bumps the version

note we likely will have some CI failures

1. Configuring auto release note generation
2. Release action no longer a part of PR action
3. testing CI workflow is in its own workflow to be shared and callable from both release and PR actions
4. action dependencies updated to current versions and cleaned up