### PR TITLE
fixing r10k entry point from docker-entrypoint.sh to container-entryp…

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 10.1.0
+version: 10.1.1
 appVersion: 8.13.0
 description: OpenVox automates the delivery and operation of software.
 keywords: ["OpenVox", "OpenVoxserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -31,7 +31,7 @@ data:
     {{- if .Values.r10k.code.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.code.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
+    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/container-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -33,7 +33,7 @@ data:
     {{- if .Values.r10k.hiera.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.hiera.cronJob.splayLimit }} ))
     {{- end }}
-    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
+    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/container-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
     --puppetfile {{ template "r10k.hiera.args" . }} > ~/.r10k_hiera_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/openvoxview-ingress_test.yaml.snap
+++ b/tests/__snapshot__/openvoxview-ingress_test.yaml.snap
@@ -9,7 +9,7 @@ should create openvoxview ingress when enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetdb-openvoxview
     spec:
       rules:

--- a/tests/__snapshot__/puppetdb-deployment.openvoxview_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-deployment.openvoxview_test.yaml.snap
@@ -9,7 +9,7 @@ should include openvoxview sidecar when enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetdb
     spec:
       selector:
@@ -27,7 +27,7 @@ should include openvoxview sidecar when enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 8.13.0
-            helm.sh/chart: puppetserver-10.1.0
+            helm.sh/chart: puppetserver-10.1.1
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-service.openvoxview_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-service.openvoxview_test.yaml.snap
@@ -9,7 +9,7 @@ should expose openvoxview port when enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetdb
     spec:
       ports:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 8.13.0
-            helm.sh/chart: puppetserver-10.1.0
+            helm.sh/chart: puppetserver-10.1.1
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 8.13.0
-            helm.sh/chart: puppetserver-10.1.0
+            helm.sh/chart: puppetserver-10.1.1
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 8.13.0
-        helm.sh/chart: puppetserver-10.1.0
+        helm.sh/chart: puppetserver-10.1.1
       name: puppetserver-puppet-claim
     spec:
       accessModes:


### PR DESCRIPTION
### Short description
voxpupuli/r10k uses container-entrypoint.sh instead of docker-entrypoint.sh this just updates the r10k references to use the new file name

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [X] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
