### PR TITLE
add var to control if g10k or r10k image is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `global.postgresql.auth.existingSecret`| existing k8s secret that holds puppetdb and postgresql username and password |``|
 | `global.postgresql.*`| please refer to https://github.com/bitnami/charts/tree/main/bitnami/postgresql#global-parameters |``|
 | `global.r10k.image` | r10k image | `puppet/r10k`|
+| `global.r10k.g10kEnabled` | use  cronjob in g10k format | `false`|
 | `global.r10k.tag` | r10k img tag | `3.15.2`|
 | `global.r10k.imagePullPolicy`| r10k image pull policy |`IfNotPresent`|
 | `global.extraEnv.*`| add extra environment variables to all containers |``|

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -31,8 +31,12 @@ data:
     {{- if .Values.r10k.code.cronJob.splay }}
     sleep $(( RANDOM % {{ int .Values.r10k.code.cronJob.splayLimit }} ))
     {{- end }}
+    {{- if .Values.r10k.g10kEnabled }}
+    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/container-entrypoint.sh -config /etc/puppetlabs/puppet/r10k_code.yaml {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
+    {{- else }}
     {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/container-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
+    {{- end }}
     retVal=$?
     if [ "$retVal" -eq "0" ]; then
       touch {{ .Values.r10k.code.cronJob.successFile }} > /dev/null 2>&1

--- a/values.yaml
+++ b/values.yaml
@@ -646,6 +646,10 @@ r10k:
         - all
   updateStrategy:
     type: RollingUpdate
+    
+  # if you want to use g10k instead of r10k, this correct the command and args of the container
+  g10kEnabled: false
+
   code:
     resources: {}
     #  requests:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

Add the option to use the g10k Image instead of the r10k image. With the option r10k.g10kEnabled enabled the r10k cronjob is adjusted to g10k syntax. Default is false, this make sure old deployments are not affected.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
