### PR TITLE
Add variable to define additional spec for the Puppet compiler service

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.compilers.podManagementPolicy` | puppetserver compilers statefulset pod management policy | `OrderedReady`|
 | `puppetserver.compilers.fqdns.alternateServerNames` | puppetserver compilers alternate fqdns |``|
 | `puppetserver.compilers.service.type` | puppetserver compilers svc type | `ClusterIP`|
+| `puppetserver.compilers.service.additionalSpec` | additional spec for the compiler service | ``|
 | `puppetserver.compilers.service.ports` | puppetserver compilers svc exposed ports | `puppetserver`|
 | `puppetserver.compilers.service.annotations`| puppetserver compilers svc annotations |``|
 | `puppetserver.compilers.service.labels`| puppetserver compilers additional svc labels |``|

--- a/templates/puppetserver-service-compilers.yaml
+++ b/templates/puppetserver-service-compilers.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml .Values.puppetserver.compilers.service.annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.puppetserver.compilers.service.additionalSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
     {{- range $key, $value := .Values.puppetserver.compilers.service.ports }}
     - name: {{ $key }}

--- a/values.yaml
+++ b/values.yaml
@@ -519,6 +519,8 @@ puppetserver:
       #  service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
       labels: {}
       loadBalancerIP: ""
+      ## Additional service specification
+      additionalSpec: {}
       ## Headless service for Puppet Server Compilers
       headless:
         ports:


### PR DESCRIPTION
### Short description
Add the options to set additional spec for the service of the puppet compilers via the values.yaml field.

follow up from: https://github.com/OpenVoxProject/openvox-helm-chart/pull/37 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
