### PR TITLE
Dev capabilities

### DIFF
--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -104,12 +104,6 @@ spec:
               drop:
                 - all
               add:
-                - CAP_CHOWN
-                - CAP_SETUID
-                - CAP_SETGID
-                - CAP_DAC_OVERRIDE
-                - CAP_AUDIT_WRITE
-                - CAP_FOWNER
                 - CHOWN
                 - SETUID
                 - SETGID
@@ -310,12 +304,6 @@ spec:
               drop:
                 - all
               add:
-                - CAP_CHOWN
-                - CAP_SETUID
-                - CAP_SETGID
-                - CAP_DAC_OVERRIDE
-                - CAP_AUDIT_WRITE
-                - CAP_FOWNER
                 - CHOWN
                 - SETUID
                 - SETGID

--- a/templates/puppetdb-podsecuritypolicy.yaml
+++ b/templates/puppetdb-podsecuritypolicy.yaml
@@ -18,11 +18,6 @@ spec:
   requiredDropCapabilities:
     - all
   allowedCapabilities:
-    - CAP_FOWNER
-    - CAP_CHOWN
-    - CAP_SETUID
-    - CAP_SETGID
-    - CAP_DAC_OVERRIDE
     - FOWNER
     - CHOWN
     - SETUID

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -133,12 +133,6 @@ spec:
               drop:
                 - all
               add:
-                - CAP_CHOWN
-                - CAP_SETUID
-                - CAP_SETGID
-                - CAP_DAC_OVERRIDE
-                - CAP_AUDIT_WRITE
-                - CAP_FOWNER
                 - CHOWN
                 - SETUID
                 - SETGID

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -151,12 +151,6 @@ spec:
               drop:
                 - all
               add:
-                - CAP_CHOWN
-                - CAP_SETUID
-                - CAP_SETGID
-                - CAP_DAC_OVERRIDE
-                - CAP_AUDIT_WRITE
-                - CAP_FOWNER
                 - CHOWN
                 - SETUID
                 - SETGID

--- a/templates/puppetserver-podsecuritypolicy.yaml
+++ b/templates/puppetserver-podsecuritypolicy.yaml
@@ -23,12 +23,6 @@ spec:
   requiredDropCapabilities:
     - all
   allowedCapabilities:
-    - CAP_CHOWN
-    - CAP_SETUID
-    - CAP_SETGID
-    - CAP_DAC_OVERRIDE
-    - CAP_AUDIT_WRITE
-    - CAP_FOWNER
     - CHOWN
     - SETUID
     - SETGID

--- a/templates/puppetserver-statefulset-compilers.yaml
+++ b/templates/puppetserver-statefulset-compilers.yaml
@@ -138,12 +138,6 @@ spec:
               drop:
                 - all
               add:
-                - CAP_CHOWN
-                - CAP_SETUID
-                - CAP_SETGID
-                - CAP_DAC_OVERRIDE
-                - CAP_AUDIT_WRITE
-                - CAP_FOWNER
                 - CHOWN
                 - SETUID
                 - SETGID

--- a/values.yaml
+++ b/values.yaml
@@ -609,12 +609,6 @@ puppetserver:
       drop:
         - all
       add:
-        - CAP_CHOWN
-        - CAP_SETUID
-        - CAP_SETGID
-        - CAP_DAC_OVERRIDE
-        - CAP_AUDIT_WRITE
-        - CAP_FOWNER
         - CHOWN
         - SETUID
         - SETGID
@@ -782,11 +776,6 @@ puppetdb:
       drop:
         - all
       add:
-        - CAP_FOWNER
-        - CAP_CHOWN
-        - CAP_SETUID
-        - CAP_SETGID
-        - CAP_DAC_OVERRIDE
         - FOWNER
         - CHOWN
         - SETUID


### PR DESCRIPTION
### Short description
Followup of https://github.com/OpenVoxProject/openvox-helm-chart/pull/37 

Remove old not used CAP_xx capabilites. The should be written without leading CAP_

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
